### PR TITLE
Fetch all studentInfo in tracker-controller

### DIFF
--- a/src/controllers/tracker-controller.js
+++ b/src/controllers/tracker-controller.js
@@ -20,20 +20,46 @@ status = "Not Submitted"
 */
 
 async function track(req, res) {
-  console.log("request", req);
-  // Yunice's code (originally in hmwk-service.js)
+  console.log(
+    `Incoming track request with request.body=${JSON.stringify(req.body)}`
+  );
 
-  // const { payload } = req.body;
-  // const { inboundFieldValues } = payload;
-  // const { studentsBoardId } = inboundFieldValues;
+  // unmarshal
+  const { payload } = req.body;
+  const { inboundFieldValues } = payload;
+  const {
+    studentsBoardId,
+    hmwkCompletionTrackingBoardId,
+    hmwkAssignmentsBoardId,
+    itemId,
+  } = inboundFieldValues;
+  console.log(
+    `
+    Unmarshalled request: studentsBoardId=${studentsBoardId},
+    hmwkCompletionTrackingBoardId=${hmwkCompletionTrackingBoardId},
+    hmwkAssignmentsBoardId=${hmwkAssignmentsBoardId}
+    itemId=${itemId}
+    `
+  );
 
-  // const students = await HmwkService.getAllStudents(studentsBoardId);
-  // if (!students) {
-  //   console.log("You have no students on the board")
-  //   return res.status(200).send({});
-  // }
+  const studentInfo = await _getStudentInfo(studentsBoardId);
+  console.log(
+    `Fetched all students from student Board: ${JSON.stringify(studentInfo)}`
+  );
+
+  // TODO: generate unique link for each student
 
   return res.status(200).send({});
+}
+
+async function _getStudentInfo(studentsBoardId) {
+  const studentInfo = await HmwkService.getAllStudents(studentsBoardId);
+  if (!studentInfo || studentInfo.length == 0) {
+    console.log("You have no students on the board");
+    return res.status(200).send({});
+  }
+
+  return studentInfo;
 }
 
 module.exports = {

--- a/src/services/hmwk-service.js
+++ b/src/services/hmwk-service.js
@@ -6,7 +6,7 @@ class HmwkService {
   static async getAllStudents(studentsBoardId) {
     const query = `
       query {
-        boards(ids: $studentsBoardId) {
+        boards(ids: ${studentsBoardId}) {
           items {
             name
             column_values {
@@ -17,10 +17,10 @@ class HmwkService {
         }
       }`;
 
-    const variables = { studentsBoardId };
+    const response = await monday.api(query);
 
-    const response = await monday.api(query, { variables });
-    const studentInfo = response.data.boards.items;
+    // Since we are only querying 1 single students Board), index 0 at boards array
+    const studentInfo = response.data.boards[0].items;
     return studentInfo; //array of json
     //student name: student_info[i].name
     //student email: student_info[i].column_values.text
@@ -28,16 +28,21 @@ class HmwkService {
 
   static async createNewHmwk(hmwkCompletionTrackingBoardId, hmwkName) {
     //create a group at HmwkCompletionTrackingBoard with hmwkName
-    const query = `
+    const mutation = `
       mutation {
-        create_group (board_id: $hmwkCompletionTrackingBoardId, group_name: $hmwkName) {
+        create_group (board_id: ${hmwkCompletionTrackingBoardId}, group_name: ${hmwkName}) {
           id
         }
       }`;
 
-    const variables = { hmwkCompletionTrackingBoardId, hmwkName };
+    const resp = await monday.api(mutation);
+    if (resp.errors) {
+      console.log(`Received errors while creating new hmwk: ${resp.errors}`);
+      throw resp.errors;
+    }
 
-    await monday.api(query, { variables });
+    const groupId = resp.data.create_group.id;
+    console.log(`Created group ${groupId} under hmwkCompletionTrackingBoard`);
   }
 
   static async populateHmwkCompletionTrackingBoard(


### PR DESCRIPTION
Upon status changed to "Send To Student", our app is able to fetch students from the student board and log to the console(currently)

Once this PR is merged, I will work on the next piece which is to generate a unique link and populate hmwk completion tracking Board.

Tested locally and verified that it worked appropriately:
```
rtlin@Ruitians-MBP ~/Project/hmwk -  (rtlin) $ npm run server-dev

> monday-integration-quickstart-app@0.0.1 server-dev /Users/rtlin/Project/hmwk
> NODE_ENV=dev node ./src/app.js

Quickstart app listening at http://localhost:8302
Incoming track request with request.body={"payload":{"blockKind":"action","blockMetadata":null,"inboundFieldValues":{"hmwkAssignmentsBoardId":862265004,"itemId":862265019,"hmwkCompletionTrackingBoardId":862265008,"studentsBoardId":862265014},"inputFields":{"hmwkAssignmentsBoardId":862265004,"itemId":862265019,"hmwkCompletionTrackingBoardId":862265008,"studentsBoardId":862265014},"recipeId":227173,"integrationId":24578533}}

    Unmarshalled request: studentsBoardId=862265014,
    hmwkCompletionTrackingBoardId=862265008,
    hmwkAssignmentsBoardId=862265004
    itemId=862265019
    
Fetched all students from student Board: [{"name":"Student 1","column_values":[{"value":"{\"email\":\"student1@example.com\",\"text\":\"student1@example.com\",\"changed_at\":\"2020-11-06T22:58:04.700Z\"}","text":"student1@example.com"}]},{"name":"Student 2","column_values":[{"value":"{\"email\":\"student2@example.com\",\"text\":\"student2@example.com\",\"changed_at\":\"2020-11-06T22:58:07.772Z\"}","text":"student2@example.com"}]},{"name":"Student 3","column_values":[{"value":"{\"email\":\"student3@example.com\",\"text\":\"student3@example.com\",\"changed_at\":\"2020-11-06T22:58:12.133Z\"}","text":"student3@example.com"}]}]
POST /tracker/track 200 1461.388 ms - 2
```