### PR TITLE
Add Procfile for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node index.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node index.js
+web: node ./src/app.js


### PR DESCRIPTION
We are encountering the following errors when going to the app URL. I suspect this issue has to do with the `Procfile` not set up. More about the `Procfile` can be found [here](https://devcenter.heroku.com/articles/getting-started-with-nodejs#define-a-procfile) and [here](https://devcenter.heroku.com/articles/procfile). 
```
2020-11-28T20:32:08.281616+00:00 heroku[router]: at=error code=H14 desc="No web processes running" method=GET path="/" host=hmwkhmwk.herokuapp.com request_id=6add4f0f-524c-4d65-8755-5654bd894dbb fwd="100.12.86.233" dyno= connect= service= status=503 bytes= protocol=https
2020-11-28T20:32:08.798355+00:00 heroku[router]: at=error code=H14 desc="No web processes running" method=GET path="/favicon.ico" host=hmwkhmwk.herokuapp.com request_id=6311d132-f417-4cc2-baa8-38ae06f8a20e fwd="100.12.86.233" dyno= connect= service= status=503 bytes= protocol=https
2020-11-28T20:34:57.800083+00:00 heroku[router]: at=error code=H14 desc="No web processes running" method=GET path="/" host=hmwkhmwk.herokuapp.com request_id=cadeea43-e04a-4e6b-b494-2b555bcdf25f fwd="100.12.86.233" dyno= connect= service= status=503 bytes= protocol=https
2020-11-28T20:34:58.438117+00:00 heroku[router]: at=error code=H14 desc="No web processes running" method=GET path="/favicon.ico" host=hmwkhmwk.herokuapp.com request_id=a352b6ea-4b56-460e-a0b9-71c98035968f fwd="100.12.86.233" dyno= connect= service= status=503 bytes= protocol=https
```